### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          - '5.10'
+          - '5.10-buster'
           - latest
     container:
       image: perl:${{ matrix.perl-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: perl:${{ matrix.perl-version }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: perl version
         run: perl -V
       - name: Install minilla

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,7 @@ jobs:
         run: perl -V
       - name: Install minilla
         run: cpanm -n Minilla
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: minil test
         run: minil test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
         run: perl -V
       - name: Install minilla
         run: cpanm -n Minilla
+      - name: Preinstall OAuth::Lite without tests # workaround for OpenSSL 3 issues
+        run: cpanm -n --notest OAuth::Lite::Consumer
       - name: Mark workspace as safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: minil test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          - '5.10-buster'
+          - '5.14-buster'
           - latest
     container:
       image: perl:${{ matrix.perl-version }}


### PR DESCRIPTION
* Adjust tested Perl versions matrix: replace 5.10 with 5.14
  - CI now only supports testing within versions >= 5.14.
  - Plack requires Perl 5.12 and IO::Socket::IP requires Perl 5.14
* Preinstall `OAuth::Lite::Consumer` with `--notest`
  - Tests fail under OpenSSL 3, so apply a workaround
* Bump `actions/checkout` from v1 to v5 (pinned by commit SHA)
* Mark `$GITHUB_WORKSPACE` as a safe git `safe.directory`

